### PR TITLE
Use 'go install' instead of 'go get' for installing binaries.

### DIFF
--- a/Makefile.helper.mk
+++ b/Makefile.helper.mk
@@ -21,11 +21,11 @@ patch:
 	cp .patches/install.patch.go vendor/helm.sh/helm/v3/pkg/action/.
 	OUT="$(shell patch -p1 -N -i .patches/helm.patch)" || echo "${OUT}" | grep "Skipping patch" -q || (echo $OUT && false)
 
-kube-lint: kube-linter
-	$(KUBELINTER) lint $(YAMLFILES)
+kube-lint:
+	kube-linter lint $(YAMLFILES)
 
-lint: patch golangci-lint
-	$(GOLANGCILINT) run -v --timeout 5m0s
+lint: patch
+	golangci-lint run -v --timeout 5m0s
 
 verify: patch vet
 	if [ `gofmt -l . | grep -v vendor | wc -l` -ne 0 ]; then \
@@ -45,16 +45,6 @@ e2e-test:
 	for d in basic; do \
           KUBERNETES_CONFIG="$(KUBECONFIG)" go test -v -timeout 40m ./test/e2e/$$d -ginkgo.v -ginkgo.noColor -ginkgo.failFast || exit; \
         done
-
-# Download kube-linter locally if necessary
-KUBELINTER = $(shell pwd)/bin/kube-linter
-kube-linter:
-	$(call go-get-tool,$(KUBELINTER),golang.stackrox.io/kube-linter/cmd/kube-linter@v0.0.0-20210328011908-cb34f2cc447f)
-
-# Download golangci-lint locally if necessary
-GOLANGCILINT = $(shell pwd)/bin/golangci-lint
-golangci-lint:
-	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0)
 
 # Additional bundle options for ART
 DEFAULT_CHANNEL="4.9"

--- a/scripts/go_install_binaries.sh
+++ b/scripts/go_install_binaries.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1
+go install golang.stackrox.io/kube-linter/cmd/kube-linter@v0.0.0-20210328011908-cb34f2cc447f
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0


### PR DESCRIPTION
go get is deprecated for installing binaries

Also I have created a single target for installing all the binaries,
other targets won't install binaries themselves as this is not an
expected behavior from the user side.

Also removed the installation of
sigs.k8s.io/controller-runtime/tools/setup-envtest as it is not used
anyware.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>