### PR TITLE
Moving all image-building dependencies to be executed in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ COPY api/ api/
 COPY cmd/ cmd/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY charts/ charts/
+COPY config/ config/
 
-RUN ["make", "manager", "helm-plugins/cm-getter/cm-getter"]
+RUN ["make", "helm-repo-index", "manager", "helm-plugins/cm-getter/cm-getter"]
 
 FROM debian:bullseye-slim
 
@@ -37,8 +39,8 @@ ENV HELM_PLUGINS /opt/helm-plugins
 
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/helm-plugins ${HELM_PLUGINS}
-
-COPY build/charts/ /charts/
+COPY --from=builder /workspace/build/charts /
+COPY --from=builder /workspace/config .
 
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ manager: patch generate ## Build manager binary.
 run: manifests generate ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run -mod=vendor ./main.go
 
-local-image-build: helm-lint helm-repo-index generate manifests-gen ## Build container image with the manager.
+local-image-build: ## Build container image with the manager.
 	$(CONTAINER_COMMAND) build -t $(IMG) .
 
 local-image-push: ## Push docker image with the manager.

--- a/Makefile.helm.mk
+++ b/Makefile.helm.mk
@@ -6,19 +6,19 @@ HELM_REPOS = $(shell ls -d $(HELM_BUILD_DIR)/*/)
 
 helm-lint: helm helm-copy-charts
 	echo $(HELM_REPOS)
-	@for repo in $(HELM_REPOS); do                          \
-		cd $$repo;                              \
+	@for repo in $(HELM_REPOS); do \
+		cd $$repo; \
 		helm lint -f ../global-values.yaml `ls -d */`; \
-		cd ../../..;                                    \
+		cd ../../..; \
 	done
 
 helm-repo-index: helm-lint
-	@for repo in $(HELM_REPOS); do                  \
-		cd $$repo;                              \
-		helm package `ls -d */`;                \
-		file_url=`echo $$repo |sed 's/$(HELM_BUILD_ROOT_DIR)\///g'`;   \
+	@for repo in $(HELM_REPOS); do \
+		cd $$repo; \
+		helm package `ls -d */`; \
+		file_url=`echo $$repo |sed 's/$(HELM_BUILD_ROOT_DIR)\///g'`; \
 		helm repo index . --url=file:///$$file_url; \
-		cd ../../..;	                        \
+		cd ../../..; \
 	done
 
 


### PR DESCRIPTION
There are multiple benefits for that change:

    * Dockerfile isn't related on any dependency and can be built using
      'podman build' directly, and it fact, this is what the CI is
      trying to do without success ATM.

    * All the patching and hacking are done inside the build container,
      therefore, our repo, which is under git control, stays clean
      after building the image.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>